### PR TITLE
global: use concise spdx license header

### DIFF
--- a/app/src/main/kotlin/fr/hnit/babyname/AboutActivity.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/AboutActivity.kt
@@ -1,26 +1,13 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.os.Bundle
 import android.widget.TextView
 import androidx.appcompat.app.AppCompatActivity
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class AboutActivity : AppCompatActivity() {
     override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/fr/hnit/babyname/BabyName.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/BabyName.kt
@@ -1,25 +1,12 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.Context
 import java.io.Serializable
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class BabyName(var name: String, var isMale: Boolean, var isFemale: Boolean, var origins: HashSet<String>) : Serializable {
     var id = nextId++

--- a/app/src/main/kotlin/fr/hnit/babyname/BabyNameDatabase.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/BabyNameDatabase.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.Context
@@ -5,24 +10,6 @@ import android.util.SparseArray
 import java.io.BufferedReader
 import java.io.IOException
 import java.io.InputStreamReader
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class BabyNameDatabase : SparseArray<BabyName>() {
     fun initialize(ctx: Context) {

--- a/app/src/main/kotlin/fr/hnit/babyname/BabyNameProject.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/BabyNameProject.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.Context
@@ -9,24 +14,6 @@ import java.io.Serializable
 import java.util.UUID
 import java.util.regex.Pattern
 import kotlin.math.min
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class BabyNameProject() : Serializable {
     var needSaving = false

--- a/app/src/main/kotlin/fr/hnit/babyname/EditActivity.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/EditActivity.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.graphics.Color
@@ -14,24 +19,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
 import java.util.regex.Pattern
 import java.util.regex.PatternSyntaxException
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class EditActivity : AppCompatActivity() {
     lateinit var project: BabyNameProject

--- a/app/src/main/kotlin/fr/hnit/babyname/FlipSearchActivity.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/FlipSearchActivity.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.DialogInterface
@@ -15,24 +20,6 @@ import android.widget.Toast
 import androidx.appcompat.app.AlertDialog
 import androidx.appcompat.app.AppCompatActivity
 import com.google.android.material.snackbar.Snackbar
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 open class FlipSearchActivity : AppCompatActivity() {
     private lateinit var project: BabyNameProject

--- a/app/src/main/kotlin/fr/hnit/babyname/Log.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/Log.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.util.Log

--- a/app/src/main/kotlin/fr/hnit/babyname/MainActivity.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/MainActivity.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.app.AlertDialog
@@ -14,24 +19,6 @@ import android.widget.AdapterView.AdapterContextMenuInfo
 import android.widget.ListView
 import android.widget.Toast
 import androidx.appcompat.app.AppCompatActivity
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class MainActivity : AppCompatActivity() {
     private lateinit var namesListView: ListView

--- a/app/src/main/kotlin/fr/hnit/babyname/OriginAdapter.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/OriginAdapter.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.Context

--- a/app/src/main/kotlin/fr/hnit/babyname/Origins.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/Origins.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.Context

--- a/app/src/main/kotlin/fr/hnit/babyname/ProjectListAdapter.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/ProjectListAdapter.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.content.Context
@@ -7,24 +12,6 @@ import android.view.ViewGroup
 import android.widget.ArrayAdapter
 import android.widget.ImageButton
 import android.widget.TextView
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class ProjectListAdapter(private val main: MainActivity, private val itemsArrayList: ArrayList<BabyNameProject>) :
     ArrayAdapter<BabyNameProject>(main, R.layout.item_project, itemsArrayList) {

--- a/app/src/main/kotlin/fr/hnit/babyname/ScrollSearchActivity.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/ScrollSearchActivity.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.graphics.Color
@@ -10,24 +15,6 @@ import androidx.recyclerview.widget.ItemTouchHelper
 import androidx.recyclerview.widget.LinearLayoutManager
 import androidx.recyclerview.widget.RecyclerView
 import com.google.android.material.snackbar.Snackbar
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 open class ScrollSearchActivity : AppCompatActivity() {
     private lateinit var project: BabyNameProject

--- a/app/src/main/kotlin/fr/hnit/babyname/ScrollSearchAdapter.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/ScrollSearchAdapter.kt
@@ -1,3 +1,8 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.view.LayoutInflater
@@ -6,24 +11,6 @@ import android.view.ViewGroup
 import android.widget.RatingBar
 import android.widget.TextView
 import androidx.recyclerview.widget.RecyclerView
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class ScrollSearchAdapter(private val scrollActivity: ScrollSearchActivity, private val project: BabyNameProject)
     : RecyclerView.Adapter<ScrollSearchAdapter.ViewHolder>() {

--- a/app/src/main/kotlin/fr/hnit/babyname/SettingsActivity.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/SettingsActivity.kt
@@ -1,25 +1,12 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.os.Bundle
 import android.preference.PreferenceActivity
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class SettingsActivity : PreferenceActivity() {
     public override fun onCreate(savedInstanceState: Bundle?) {

--- a/app/src/main/kotlin/fr/hnit/babyname/SettingsFragment.kt
+++ b/app/src/main/kotlin/fr/hnit/babyname/SettingsFragment.kt
@@ -1,25 +1,12 @@
+/*
+* Copyright (C) 2025 Baby Name Developers
+* SPDX-License-Identifier: GPL-3.0-or-later
+*/
+
 package fr.hnit.babyname
 
 import android.os.Bundle
 import android.preference.PreferenceFragment
-
-/*
-The Baby Name app is free software: you can redistribute it
-and/or modify it under the terms of the GNU General Public
-License as published by the Free Software Foundation,
-either version 2 of the License, or (at your option) any
-later version.
-
-The Baby Name app is distributed in the hope that it will be
-useful, but WITHOUT ANY WARRANTY; without even the implied
-warranty of MERCHANTABILITY or FITNESS FOR A PARTICULAR
-PURPOSE. See the GNU General Public License for more
-details.
-
-You should have received a copy of the GNU General
-Public License along with the TXM platform. If not, see
-http://www.gnu.org/licenses
-*/
 
 class SettingsFragment : PreferenceFragment() {
     override fun onCreate(savedInstanceState: Bundle?) {


### PR DESCRIPTION
This kind of license header has become popular and widly accepted (e.g. in the commercial sector). 